### PR TITLE
Added support to specify index output file name, plus fixed issue with threads

### DIFF
--- a/snakemake_wrapper_utils/samtools.py
+++ b/snakemake_wrapper_utils/samtools.py
@@ -2,10 +2,17 @@ import sys
 from os import path
 
 
-def get_samtools_opts(snakemake, parse_threads=True, parse_output_format=True):
+def get_samtools_opts(
+    snakemake,
+    parse_threads=True,
+    parse_write_index=True,
+    parse_output=True,
+    parse_output_format=True,
+):
     """Obtain samtools_opts from output, params, and handle resource definitions in resources."""
     samtools_opts = ""
     extra = snakemake.params.get("extra", "")
+    idx = snakemake.output.get("idx", "")
 
     ###############
     ### Threads ###
@@ -18,8 +25,31 @@ def get_samtools_opts(snakemake, parse_threads=True, parse_output_format=True):
             samtools_opts += (
                 ""
                 if snakemake.threads <= 1
-                else "--threads {}".format(snakemake.threads - 1)
+                else " --threads {}".format(snakemake.threads - 1)
             )
+
+    ###################
+    ### Write index ###
+    ###################
+    if parse_write_index:
+        if "--write-index" in extra:
+            sys.exit(
+                "You have specified writing index (`--write-index`) in params.extra; this is automatically infered from `idx` output file."
+            )
+            if idx:
+                samtools_opts += " --write-index"
+
+    ###################
+    ### Output file ###
+    ###################
+    if parse_output:
+        if "-o" in extra:
+            sys.exit(
+                "You have specified output file (`-o`) in params.extra; this is automatically infered from the first output file."
+            )
+            samtools_opts += " -o {snakemake.output[0]}"
+            if idx:
+                samtools_opts += f"##idx##{idx}"
 
     #####################
     ### Output format ###
@@ -29,7 +59,6 @@ def get_samtools_opts(snakemake, parse_threads=True, parse_output_format=True):
             sys.exit(
                 "You have specified output format (`-O/--output-fmt`) in params.extra; this is automatically infered from output file extension."
             )
-
         out_name, out_ext = path.splitext(snakemake.output[0])
         out_ext = out_ext[1:].upper()
         samtools_opts += f" --output-fmt {out_ext}"

--- a/snakemake_wrapper_utils/samtools.py
+++ b/snakemake_wrapper_utils/samtools.py
@@ -22,11 +22,11 @@ def get_samtools_opts(
             sys.exit(
                 "You have specified number of threads (`-@/--threads`) in params.extra; please use only `threads`."
             )
-            samtools_opts += (
-                ""
-                if snakemake.threads <= 1
-                else " --threads {}".format(snakemake.threads - 1)
-            )
+        samtools_opts += (
+            ""
+            if snakemake.threads <= 1
+            else " --threads {}".format(snakemake.threads - 1)
+        )
 
     ###################
     ### Write index ###
@@ -36,8 +36,8 @@ def get_samtools_opts(
             sys.exit(
                 "You have specified writing index (`--write-index`) in params.extra; this is automatically infered from `idx` output file."
             )
-            if idx:
-                samtools_opts += " --write-index"
+        if idx:
+            samtools_opts += " --write-index"
 
     ###################
     ### Output file ###
@@ -47,9 +47,9 @@ def get_samtools_opts(
             sys.exit(
                 "You have specified output file (`-o`) in params.extra; this is automatically infered from the first output file."
             )
-            samtools_opts += " -o {snakemake.output[0]}"
-            if idx:
-                samtools_opts += f"##idx##{idx}"
+        samtools_opts += f" -o {snakemake.output[0]}"
+        if idx:
+            samtools_opts += f"##idx##{idx}"
 
     #####################
     ### Output format ###


### PR DESCRIPTION

I've added support to specify index output file name, if it has been specified in `snakemake.output.idx`.

However, the way `samtools` allows for it is through the `output` argument, and that mean that I also need to parse it.
Not sure if it is too much, even though the wrapper command line becomes quite clean (e.g.):
```
"samtools view {snakemake.params.extra} {samtools_opts} {snakemake.input[0]} {log}"
```
