### PR TITLE
feat: function for output format inference and disable temp folder

### DIFF
--- a/snakemake_wrapper_utils/bcftools.py
+++ b/snakemake_wrapper_utils/bcftools.py
@@ -2,13 +2,13 @@ import sys
 
 
 
-def infer_out_format(output):
+def infer_out_format(output, uncompressed_bcf = False):
     if output.endswith(".vcf"):
         out_format = "v"
     elif output.endswith(".vcf.gz"):
         out_format = "z"
     elif output.endswith(".bcf"):
-        if snakemake.params.get("uncompressed_bcf", False):
+        if uncompressed_bcf:
             out_format = "u"
         else:
             out_format = "b"
@@ -52,7 +52,7 @@ def get_bcftools_opts(
                 "You have specified output format (`-O/--output-type`) in `params.extra`; this is automatically infered from output file extension."
             )
 
-        out_format = infer_out_format(snakemake.output[0])
+        out_format = infer_out_format(snakemake.output[0], snakemake.params.get("uncompressed_bcf", False))
         bcftools_opts += f" --output-type {out_format}"
 
     ##############

--- a/snakemake_wrapper_utils/bcftools.py
+++ b/snakemake_wrapper_utils/bcftools.py
@@ -35,7 +35,7 @@ def get_bcftools_opts(
     if parse_threads:
         if "--threads" in extra:
             sys.exit(
-                "You have specified number of threads (`--threads`) in params.extra; please use only `threads`."
+                "You have specified number of threads (`--threads`) in `params.extra`; please use `threads`."
             )
         bcftools_opts += (
             ""
@@ -49,7 +49,7 @@ def get_bcftools_opts(
     if parse_output_format:
         if "-O" in extra or "--output-type" in extra:
             sys.exit(
-                "You have specified output format (`-O/--output-type`) in params.extra; this is automatically infered from output file extension."
+                "You have specified output format (`-O/--output-type`) in `params.extra`; this is automatically infered from output file extension."
             )
 
         out_format = infer_out_format(snakemake.output[0])
@@ -61,7 +61,7 @@ def get_bcftools_opts(
     if parse_memory:
         if "-m" in extra or "--max-mem" in extra:
             sys.exit(
-                "You have provided `-m/--max-mem` in params.extra; please use resources.mem_mb."
+                "You have provided `-m/--max-mem` in `params.extra`; please use `resources.mem_mb`."
             )
         # Getting memory in megabytes, as advised in documentation.
         if "mem_mb" in snakemake.resources.keys():
@@ -76,7 +76,7 @@ def get_bcftools_opts(
     ################
     if "-T" in extra or "--temp-dir" in extra:
         sys.exit(
-            "You have provided `-T/--temp-dir` in params.extra; please use resources.tmpdir."
+            "You have provided `-T/--temp-dir` in `params.extra`; please use `resources.tmpdir`."
         )
 
     return bcftools_opts

--- a/snakemake_wrapper_utils/bcftools.py
+++ b/snakemake_wrapper_utils/bcftools.py
@@ -83,9 +83,9 @@ def get_bcftools_opts(
     ################
     ### Temp dir ###
     ################
-    if "-T" in extra or "--temp-dir" in extra:
+    if "-T" in extra or "--temp-dir" in extra or "--temp-prefix" in extra:
         sys.exit(
-            "You have provided `-T/--temp-dir` in `params.extra`; please use `resources.tmpdir`."
+            "You have provided `-T/--temp-dir/--temp-prefix` in `params.extra`; please use `resources.tmpdir`."
         )
 
     return bcftools_opts

--- a/snakemake_wrapper_utils/bcftools.py
+++ b/snakemake_wrapper_utils/bcftools.py
@@ -18,6 +18,7 @@ def infer_out_format(output, uncompressed_bcf=False):
 def get_bcftools_opts(
     snakemake,
     parse_threads=True,
+    parse_ref=True,
     parse_output=True,
     parse_output_format=True,
     parse_memory=True,
@@ -39,6 +40,18 @@ def get_bcftools_opts(
             if snakemake.threads <= 1
             else "--threads {}".format(snakemake.threads - 1)
         )
+
+    ######################
+    ### Reference file ###
+    ######################
+    if parse_ref:
+        if "-f" in extra or "--fasta-ref" in extra:
+            sys.exit(
+                "You have specified reference file (`-f/--fasta-ref`) in `params.extra`; this is automatically infered from the `ref` output file."
+            )
+
+        if snakemake.output.get("ref"):
+            bcftools_opts += f" --fasta-ref {snakemake.output.ref}"
 
     ###################
     ### Output file ###

--- a/snakemake_wrapper_utils/bcftools.py
+++ b/snakemake_wrapper_utils/bcftools.py
@@ -12,7 +12,7 @@ def infer_out_format(output, uncompressed_bcf=False):
         else:
             out_format = "b"
     else:
-        raise ValueError("invalid output file extension ('.vcf', '.vcf.gz', '.bcf').")
+        raise ValueError("invalid output file format ('.vcf', '.vcf.gz', '.bcf').")
 
 
 def get_bcftools_opts(
@@ -23,7 +23,7 @@ def get_bcftools_opts(
     parse_output_format=True,
     parse_memory=True,
 ):
-    """Obtain bcftools_opts from output, params, and handle resource definitions in resources."""
+    """Obtain bcftools_opts from output, params, and handle resource definitions."""
     bcftools_opts = ""
     extra = snakemake.params.get("extra", "")
 

--- a/snakemake_wrapper_utils/bcftools.py
+++ b/snakemake_wrapper_utils/bcftools.py
@@ -1,8 +1,7 @@
 import sys
 
 
-
-def infer_out_format(output, uncompressed_bcf = False):
+def infer_out_format(output, uncompressed_bcf=False):
     if output.endswith(".vcf"):
         out_format = "v"
     elif output.endswith(".vcf.gz"):
@@ -13,15 +12,13 @@ def infer_out_format(output, uncompressed_bcf = False):
         else:
             out_format = "b"
     else:
-        raise ValueError(
-            "invalid output file extension ('.vcf', '.vcf.gz', '.bcf')."
-        )
-
+        raise ValueError("invalid output file extension ('.vcf', '.vcf.gz', '.bcf').")
 
 
 def get_bcftools_opts(
     snakemake,
     parse_threads=True,
+    parse_output=True,
     parse_output_format=True,
     parse_memory=True,
 ):
@@ -43,6 +40,16 @@ def get_bcftools_opts(
             else "--threads {}".format(snakemake.threads - 1)
         )
 
+    ###################
+    ### Output file ###
+    ###################
+    if parse_output:
+        if "-o" in extra or "--output" in extra:
+            sys.exit(
+                "You have specified output file (`-o/--output`) in `params.extra`; this is automatically infered from the first output file."
+            )
+        bcftools_opts += f" -o {snakemake.output[0]}"
+
     #####################
     ### Output format ###
     #####################
@@ -52,7 +59,9 @@ def get_bcftools_opts(
                 "You have specified output format (`-O/--output-type`) in `params.extra`; this is automatically infered from output file extension."
             )
 
-        out_format = infer_out_format(snakemake.output[0], snakemake.params.get("uncompressed_bcf", False))
+        out_format = infer_out_format(
+            snakemake.output[0], snakemake.params.get("uncompressed_bcf", False)
+        )
         bcftools_opts += f" --output-type {out_format}"
 
     ##############

--- a/snakemake_wrapper_utils/samtools.py
+++ b/snakemake_wrapper_utils/samtools.py
@@ -2,6 +2,13 @@ import sys
 from os import path
 
 
+
+def infer_out_format(output):
+    out_name, out_ext = path.splitext(file_name)
+    return out_ext[1:].upper()
+
+
+
 def get_samtools_opts(
     snakemake,
     parse_threads=True,
@@ -59,8 +66,7 @@ def get_samtools_opts(
             sys.exit(
                 "You have specified output format (`-O/--output-fmt`) in params.extra; this is automatically infered from output file extension."
             )
-        out_name, out_ext = path.splitext(snakemake.output[0])
-        out_ext = out_ext[1:].upper()
+        out_ext = infer_out_format(snakemake.output[0])
         samtools_opts += f" --output-fmt {out_ext}"
 
     return samtools_opts


### PR DESCRIPTION

Create function to infer output format, both to simplify code but also so that function can be called by other wrappers.

Disabled parsing of temp dir since it should be handled by `tempfile` in each wrapper.