### PR TITLE
fix: rename argument in function 'infer_out_format'

### DIFF
--- a/snakemake_wrapper_utils/samtools.py
+++ b/snakemake_wrapper_utils/samtools.py
@@ -3,7 +3,7 @@ from os import path
 
 
 
-def infer_out_format(output):
+def infer_out_format(file_name):
     out_name, out_ext = path.splitext(file_name)
     return out_ext[1:].upper()
 


### PR DESCRIPTION
Hi, this is in relation to #16.

**Summary of changes**
  - Rename input argument so that 'path.splitext' is called on the correct variable

Please feel free to request any changes.

Thank you,
V