### PR TITLE
feat: Regions, samples and targets in get_bcftools_opts

### DIFF
--- a/snakemake_wrapper_utils/bcftools.py
+++ b/snakemake_wrapper_utils/bcftools.py
@@ -30,7 +30,6 @@ def get_bcftools_opts(
     bcftools_opts = ""
     extra = snakemake.params.get("extra", "")
 
-
     ###############
     ### Threads ###
     ###############
@@ -45,7 +44,6 @@ def get_bcftools_opts(
             else "--threads {}".format(snakemake.threads - 1)
         )
 
-
     ######################
     ### Reference file ###
     ######################
@@ -58,7 +56,6 @@ def get_bcftools_opts(
         if snakemake.input.get("ref"):
             bcftools_opts += f" --fasta-ref {snakemake.input.ref}"
 
-    
     ####################
     ### Regions file ###
     ####################
@@ -70,7 +67,6 @@ def get_bcftools_opts(
 
         if snakemake.input.get("regions"):
             bcftools_opts += f" --regions-file {snakemake.input.regions}"
-
 
     ####################
     ### Samples file ###
@@ -84,7 +80,6 @@ def get_bcftools_opts(
         if snakemake.input.get("samples"):
             bcftools_opts += f" --samples-file {snakemake.input.samples}"
 
-
     ####################
     ### Targets file ###
     ####################
@@ -97,7 +92,6 @@ def get_bcftools_opts(
         if snakemake.input.get("targets"):
             bcftools_opts += f" --targets-file {snakemake.input.targets}"
 
-
     ###################
     ### Output file ###
     ###################
@@ -107,7 +101,6 @@ def get_bcftools_opts(
                 "You have specified output file (`-o/--output`) in `params.extra`; this is automatically infered from the first output file."
             )
         bcftools_opts += f" -o {snakemake.output[0]}"
-
 
     #####################
     ### Output format ###
@@ -122,7 +115,6 @@ def get_bcftools_opts(
             snakemake.output[0], snakemake.params.get("uncompressed_bcf", False)
         )
         bcftools_opts += f" --output-type {out_format}"
-
 
     ##############
     ### Memory ###
@@ -140,7 +132,6 @@ def get_bcftools_opts(
         elif "mem_gb" in snakemake.resources.keys():
             bcftools_opts += " --max-mem {}G".format(snakemake.resources["mem_gb"])
 
-
     ################
     ### Temp dir ###
     ################
@@ -148,6 +139,5 @@ def get_bcftools_opts(
         sys.exit(
             "You have provided `-T/--temp-dir/--temp-prefix` in `params.extra`; please use `resources.tmpdir`."
         )
-
 
     return bcftools_opts

--- a/snakemake_wrapper_utils/bcftools.py
+++ b/snakemake_wrapper_utils/bcftools.py
@@ -19,6 +19,9 @@ def get_bcftools_opts(
     snakemake,
     parse_threads=True,
     parse_ref=True,
+    parse_region=True,
+    parse_samples=True,
+    parse_targets=True,
     parse_output=True,
     parse_output_format=True,
     parse_memory=True,
@@ -54,6 +57,45 @@ def get_bcftools_opts(
 
         if snakemake.input.get("ref"):
             bcftools_opts += f" --fasta-ref {snakemake.input.ref}"
+
+    
+    ####################
+    ### Regions file ###
+    ####################
+    if parse_region:
+        if "--region-file" in extra or "-R" in extra:
+            sys.exit(
+                "You have specified region file (`-R/--regions-file`) in `params.extra`; this is automatically infered from the `regions` input file."
+            )
+
+        if snakemake.input.get("regions"):
+            bcftools_opts += f" --regions-file {snakemake.input.regions}"
+
+
+    ####################
+    ### Samples file ###
+    ####################
+    if parse_samples:
+        if "-S" in extra or "--samples-file" in extra:
+            sys.exit(
+                "You have specified samples file (`-S/--samples-file`) in `params.extra`; this is automatically infered from the `samples` input file."
+            )
+
+        if snakemake.input.get("samples"):
+            bcftools_opts += f" --samples-file {snakemake.input.samples}"
+
+
+    ####################
+    ### Targets file ###
+    ####################
+    if parse_targets:
+        if "-T" in extra or "--targets-file" in extra:
+            sys.exit(
+                "You have specified samples file (`-T/--targets-file`) in `params.extra`; this is automatically infered from the `targets` input file."
+            )
+
+        if snakemake.input.get("targets"):
+            bcftools_opts += f" --targets-file {snakemake.input.targets}"
 
 
     ###################


### PR DESCRIPTION
# Description:

`--samples-file`, `--regions-file` and `--targets-file` makes BCFTools faster on regions of interest. These options belong to the [common options](https://samtools.github.io/bcftools/bcftools.html#common_options) listed in bcftools official documentation and are shared by all sub-commands available in bcftools. 

While the content of these files may vary in special cases in bcftools view/call, the main CLI remains the same.

I followed coding scheme, but black formatting removed double empty-lines between code blocks.