### PR TITLE
fix: check for `input: index=""`, when `input: regions=""` is specified, as the `--regions-file` option requires an index

### DIFF
--- a/snakemake_wrapper_utils/bcftools.py
+++ b/snakemake_wrapper_utils/bcftools.py
@@ -66,6 +66,10 @@ def get_bcftools_opts(
             )
 
         if snakemake.input.get("regions"):
+            if not snakemake.input.get("index"):
+                sys.exit(
+                    "You have specified a `regions=` file in `input:`; this implies the `--regions-file` option of bcftools and thus also requires an `index=` file specified in the `input:`, but none was found."
+                )
             bcftools_opts += f" --regions-file {snakemake.input.regions}"
 
     ####################


### PR DESCRIPTION
This came up in a workflow using the `bcftools filter` wrapper with the `input: regions=""` file specification right here:

https://github.com/snakemake-workflows/dna-seq-varlociraptor/issues/216