### PR TITLE
fix: fix bug when short arguments are contained in long arguments

### DIFF
--- a/snakemake_wrapper_utils/bcftools.py
+++ b/snakemake_wrapper_utils/bcftools.py
@@ -1,5 +1,5 @@
 import sys
-from snakemake import get_mem, is_arg
+from snakemake_wrapper_utils.snakemake import get_mem, is_arg
 
 
 def infer_out_format(output, uncompressed_bcf=False):

--- a/snakemake_wrapper_utils/bcftools.py
+++ b/snakemake_wrapper_utils/bcftools.py
@@ -1,4 +1,5 @@
 import sys
+from snakemake import get_mem, is_arg
 
 
 def infer_out_format(output, uncompressed_bcf=False):
@@ -34,7 +35,7 @@ def get_bcftools_opts(
     ### Threads ###
     ###############
     if parse_threads:
-        if "--threads" in extra:
+        if is_arg("--threads", extra):
             sys.exit(
                 "You have specified number of threads (`--threads`) in `params.extra`; please use `threads`."
             )
@@ -48,7 +49,7 @@ def get_bcftools_opts(
     ### Reference file ###
     ######################
     if parse_ref:
-        if "-f" in extra or "--fasta-ref" in extra:
+        if is_arg("-f", extra) or is_arg("--fasta-ref", extra):
             sys.exit(
                 "You have specified reference file (`-f/--fasta-ref`) in `params.extra`; this is automatically infered from the `ref` input file."
             )
@@ -60,7 +61,7 @@ def get_bcftools_opts(
     ### Regions file ###
     ####################
     if parse_regions:
-        if "--regions-file" in extra or "-R" in extra:
+        if is_arg("--regions-file", extra) or is_arg("-R", extra):
             sys.exit(
                 "You have specified regions file (`-R/--regions-file`) in `params.extra`; this is automatically infered from the `regions` input file."
             )
@@ -68,7 +69,7 @@ def get_bcftools_opts(
         if snakemake.input.get("regions"):
             if not snakemake.input.get("index"):
                 sys.exit(
-                    "You have specified a `regions=` file in `input:`; this implies the `--regions-file` option of bcftools and thus also requires an `index=` file specified in the `input:`, but none was found."
+                    "You have specified a `regions` file in `input:`; this implies the `--regions-file` option of bcftools and thus also requires an `index=` file specified in the `input:`, but none was found."
                 )
             bcftools_opts += f" --regions-file {snakemake.input.regions}"
 
@@ -76,7 +77,7 @@ def get_bcftools_opts(
     ### Samples file ###
     ####################
     if parse_samples:
-        if "-S" in extra or "--samples-file" in extra:
+        if is_arg("-S", extra) or is_arg("--samples-file", extra):
             sys.exit(
                 "You have specified samples file (`-S/--samples-file`) in `params.extra`; this is automatically infered from the `samples` input file."
             )
@@ -88,7 +89,7 @@ def get_bcftools_opts(
     ### Targets file ###
     ####################
     if parse_targets:
-        if "-T" in extra or "--targets-file" in extra:
+        if is_arg("-T", extra) or is_arg("--targets-file", extra):
             sys.exit(
                 "You have specified targets file (`-T/--targets-file`) in `params.extra`; this is automatically infered from the `targets` input file."
             )
@@ -100,7 +101,7 @@ def get_bcftools_opts(
     ### Output file ###
     ###################
     if parse_output:
-        if "-o" in extra or "--output" in extra:
+        if is_arg("-o", extra) or is_arg("--output", extra):
             sys.exit(
                 "You have specified output file (`-o/--output`) in `params.extra`; this is automatically infered from the first output file."
             )
@@ -110,7 +111,7 @@ def get_bcftools_opts(
     ### Output format ###
     #####################
     if parse_output_format:
-        if "-O" in extra or "--output-type" in extra:
+        if is_arg("-O", extra) or is_arg("--output-type", extra):
             sys.exit(
                 "You have specified output format (`-O/--output-type`) in `params.extra`; this is automatically infered from output file extension."
             )
@@ -124,22 +125,20 @@ def get_bcftools_opts(
     ### Memory ###
     ##############
     if parse_memory:
-        if "-m" in extra or "--max-mem" in extra:
+        if is_arg("-m", extra) or is_arg("--max-mem", extra):
             sys.exit(
                 "You have provided `-m/--max-mem` in `params.extra`; please use `resources.mem_mb`."
             )
-        # Getting memory in megabytes, as advised in documentation.
-        if "mem_mb" in snakemake.resources.keys():
-            bcftools_opts += " --max-mem {}M".format(snakemake.resources["mem_mb"])
-        # Getting memory in gigabytes, for user convenience. Please prefer the use
-        # of mem_mb over mem_gb as advised in documentation.
-        elif "mem_gb" in snakemake.resources.keys():
-            bcftools_opts += " --max-mem {}G".format(snakemake.resources["mem_gb"])
+        bcftools_opts += " --max-mem {}M".format(get_mem(snakemake))
 
     ################
     ### Temp dir ###
     ################
-    if "-T" in extra or "--temp-dir" in extra or "--temp-prefix" in extra:
+    if (
+        is_arg("-T", extra)
+        or is_arg("--temp-dir", extra)
+        or is_arg("--temp-prefix", extra)
+    ):
         sys.exit(
             "You have provided `-T/--temp-dir/--temp-prefix` in `params.extra`; please use the `tmpdir` resource."
         )

--- a/snakemake_wrapper_utils/java.py
+++ b/snakemake_wrapper_utils/java.py
@@ -1,5 +1,5 @@
 import sys
-from snakemake import get_mem, is_arg
+from snakemake_wrapper_utils.snakemake import get_mem, is_arg
 
 
 def java_mem_xmx_error(params_key):

--- a/snakemake_wrapper_utils/java.py
+++ b/snakemake_wrapper_utils/java.py
@@ -1,7 +1,10 @@
 import sys
+from snakemake import get_mem, is_arg
 
-def java_mem_xmx_error(unit, params_key):
-    return f"You have specified resources.mem_{unit} and provided `-Xmx` in params.{params_key}. For Java memory specifications, please only use resources.mem_mb (for total memory reserved for the rule) and params.java_mem_overhead_mb (to specify any required non-heap overhead that needs to be set aside before determining the -Xmx value)."
+
+def java_mem_xmx_error(params_key):
+    return f"You have specified memory under `resources` and provided `-Xmx` in params.{params_key}. For Java memory specifications, please only use resources.mem_mb (for total memory reserved for the rule) and params.java_mem_overhead_mb (to specify any required non-heap overhead that needs to be set aside before determining the `-Xmx` value)."
+
 
 def get_java_opts(snakemake, java_mem_overhead_factor=0.2):
     """Obtain java_opts from params, and handle resource definitions in resources."""
@@ -10,46 +13,28 @@ def get_java_opts(snakemake, java_mem_overhead_factor=0.2):
     extra = snakemake.params.get("extra", "")
     assert 0.0 <= java_mem_overhead_factor <= 1.0
 
-    # Getting memory in megabytes, if java opts is not filled with -Xmx parameter
-    # By doing so, backward compatibility is preserved
-    if "mem_mb" in snakemake.resources.keys():
-        if "-Xmx" in java_opts:
-            sys.exit(
-                java_mem_xmx_error("mb", "java_opts")
-            )
-        if "-Xmx" in extra:
-            sys.exit(
-                java_mem_xmx_error("mb", "extra")
-            )
-        java_opts += " -Xmx{}M".format( round( snakemake.resources["mem_mb"] * (1.0 - java_mem_overhead_factor) ) )
+    # Getting memory.
+    if is_arg("-Xmx", java_opts):
+        sys.exit(java_mem_xmx_error("java_opts"))
+    if is_arg("-Xmx", extra):
+        sys.exit(java_mem_xmx_error("extra"))
+    java_opts += " -Xmx{}M".format(
+        round(get_mem(snakemake) * (1.0 - java_mem_overhead_factor))
+    )
 
-
-    # Getting memory in gigabytes, for user convenience. Please prefer the use
-    # of mem_mb over mem_gb as advised in documentation.
-    elif "mem_gb" in snakemake.resources.keys():
-        if "-Xmx" in java_opts:
-            sys.exit(
-                java_mem_xmx_error("gb", "java_opts")
-            )
-        if "-Xmx" in extra:
-            sys.exit(
-                java_mem_xmx_error("gb", "extra")
-            )
-        java_opts += " -Xmx{}G".format( round( snakemake.resources["mem_gb"] * (1.0 - java_mem_overhead_factor) ) )
-
-
-    # Getting java temp directory from output files list, if -Djava.io.tmpdir
-    # is not provided in java parameters. By doing so, backward compatibility is
-    # not broken.
+    # Getting java temp directory
     if "java_temp" in snakemake.output.keys():
-        if "-Djava.io.tmpdir" in java_opts:
-            sys.exit(
-                "You have specified output.java_temp and provided `-Djava.io.tmpdir` in params.java_opts. Please choose the one you intended and remove the other specification."
-            )
-        if "-Djava.io.tmpdir" in extra:
-            sys.exit(
-                "You have specified output.java_temp and provided `-Djava.io.tmpdir` in params.extra. Please choose the one you intended and remove the other specification."
-            )
-        java_opts += " -Djava.io.tmpdir={}".format(snakemake.output["java_temp"])
+        sys.exit(
+            "You have specified `output.java_temp`; please use `resources.tmpdir`."
+        )
+    if is_arg("-Djava.io.tmpdir", java_opts):
+        sys.exit(
+            "You have specified `-Djava.io.tmpdir` in `params.java_opts`; please use `resources.tmpdir`."
+        )
+    if is_arg("-Djava.io.tmpdir", extra):
+        sys.exit(
+            "You have specified `-Djava.io.tmpdir` in `params.extra`; please use `resources.tmpdir`."
+        )
+    java_opts += f" -Djava.io.tmpdir={snakemake.resources.tmpdir}"
 
     return java_opts

--- a/snakemake_wrapper_utils/java.py
+++ b/snakemake_wrapper_utils/java.py
@@ -3,7 +3,7 @@ from snakemake_wrapper_utils.snakemake import get_mem, is_arg
 
 
 def java_mem_xmx_error(params_key):
-    return f"You have specified memory under `resources` and provided `-Xmx` in params.{params_key}. For Java memory specifications, please only use resources.mem_mb (for total memory reserved for the rule) and params.java_mem_overhead_mb (to specify any required non-heap overhead that needs to be set aside before determining the `-Xmx` value)."
+    return f"You have provided `-Xmx` in params.{params_key}. For Java memory specifications, please only use resources.mem_mb (for total memory reserved for the rule) and `params.java_mem_overhead_mb` (to specify any required non-heap overhead that needs to be set aside before determining the `-Xmx` value)."
 
 
 def get_java_opts(snakemake, java_mem_overhead_factor=0.2):

--- a/snakemake_wrapper_utils/java.py
+++ b/snakemake_wrapper_utils/java.py
@@ -14,9 +14,9 @@ def get_java_opts(snakemake, java_mem_overhead_factor=0.2):
     assert 0.0 <= java_mem_overhead_factor <= 1.0
 
     # Getting memory.
-    if is_arg("-Xmx", java_opts):
+    if "-Xmx" in java_opts:
         sys.exit(java_mem_xmx_error("java_opts"))
-    if is_arg("-Xmx", extra):
+    if "-Xmx" in extra:
         sys.exit(java_mem_xmx_error("extra"))
     java_opts += " -Xmx{}M".format(
         round(get_mem(snakemake) * (1.0 - java_mem_overhead_factor))

--- a/snakemake_wrapper_utils/samtools.py
+++ b/snakemake_wrapper_utils/samtools.py
@@ -1,5 +1,6 @@
 import sys
 from os import path
+from snakemake import is_arg
 
 
 def infer_out_format(file_name):
@@ -24,9 +25,9 @@ def get_samtools_opts(
     ### Threads ###
     ###############
     if parse_threads:
-        if "-@" in extra or "--threads" in extra:
+        if is_arg("-@", extra) or is_arg("--threads", extra):
             sys.exit(
-                "You have specified number of threads (`-@/--threads`) in params.extra; please use only `threads`."
+                "You have specified number of threads (`-@/--threads`) in `params.extra`; please use only `threads`."
             )
         samtools_opts += (
             ""
@@ -38,9 +39,9 @@ def get_samtools_opts(
     ### Reference file ###
     ######################
     if parse_ref:
-        if "--reference" in extra:
+        if is_arg("--reference", extra):
             sys.exit(
-                "You have specified reference file (`--reference`) in `params.extra`; this is automatically infered from the `ref` input file."
+                "You have specified reference file (`--reference`) in `params.extra`; this is automatically infered from `ref` input file."
             )
 
         if snakemake.input.get("ref"):
@@ -50,9 +51,9 @@ def get_samtools_opts(
     ### Write index ###
     ###################
     if parse_write_index:
-        if "--write-index" in extra:
+        if is_arg("--write-index", extra):
             sys.exit(
-                "You have specified writing index (`--write-index`) in params.extra; this is automatically infered from `idx` output file."
+                "You have specified writing index (`--write-index`) in `params.extra`; this is automatically infered from `idx` output file."
             )
         if idx:
             samtools_opts += " --write-index"
@@ -61,9 +62,9 @@ def get_samtools_opts(
     ### Output file ###
     ###################
     if parse_output:
-        if "-o" in extra:
+        if is_arg("-o", extra):
             sys.exit(
-                "You have specified output file (`-o`) in params.extra; this is automatically infered from the first output file."
+                "You have specified output file (`-o`) in `params.extra`; this is automatically infered from the first output file."
             )
         samtools_opts += f" -o {snakemake.output[0]}"
         if idx:
@@ -73,9 +74,9 @@ def get_samtools_opts(
     ### Output format ###
     #####################
     if parse_output_format:
-        if "-O" in extra or "--output-fmt" in extra:
+        if is_arg("-O", extra) or is_arg("--output-fmt", extra):
             sys.exit(
-                "You have specified output format (`-O/--output-fmt`) in params.extra; this is automatically infered from output file extension."
+                "You have specified output format (`-O/--output-fmt`) in `params.extra`; this is automatically infered from output file extension."
             )
         out_ext = infer_out_format(snakemake.output[0])
         samtools_opts += f" --output-fmt {out_ext}"

--- a/snakemake_wrapper_utils/samtools.py
+++ b/snakemake_wrapper_utils/samtools.py
@@ -1,6 +1,6 @@
 import sys
 from os import path
-from snakemake import is_arg
+from snakemake_wrapper_utils.snakemake import is_arg
 
 
 def infer_out_format(file_name):

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -22,6 +22,6 @@ def get_mem(snakemake, out_unit="MiB"):
 def is_arg(arg, cmd):
     """Check command for the presence of argument"""
     if arg in cmd.replace("=", " ").split(" "):
-        return False
+        return True
 
-    return True
+    return False

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -17,3 +17,11 @@ def get_mem(snakemake, out_unit="MiB"):
         return mem_mb / 1024
     else:
         raise valueError("invalid output unit. Only KiB, MiB and GiB supported.")
+
+
+def is_arg(arg, cmd):
+    """Check command for the presence of argument"""
+    if arg in cmd.replace("=", " ").split(" "):
+        return False
+
+    return True


### PR DESCRIPTION
- Some short and long options contain the same characters and will fail. For example, if option `--output-fmt-option` is set on `params.extra`, wrapper will fail and say:
```
You have specified output file (`-o`) in params.extra; this is automatically infered from the first output file.
```
- Simplified code by using function `get_mem`.
- Changed java temp to `resources.tmpdir`.
