### PR TITLE
fix: Escape the case when a valid parameter in params.extra contains "-m"

### DIFF
--- a/snakemake_wrapper_utils/bcftools.py
+++ b/snakemake_wrapper_utils/bcftools.py
@@ -124,7 +124,7 @@ def get_bcftools_opts(
     ### Memory ###
     ##############
     if parse_memory:
-        if "-m" in extra or "--max-mem" in extra:
+        if " -m" in extra or "--max-mem" in extra:
             sys.exit(
                 "You have provided `-m/--max-mem` in `params.extra`; please use `resources.mem_mb`."
             )

--- a/snakemake_wrapper_utils/bcftools.py
+++ b/snakemake_wrapper_utils/bcftools.py
@@ -124,7 +124,7 @@ def get_bcftools_opts(
     ### Memory ###
     ##############
     if parse_memory:
-        if " -m" in extra or "--max-mem" in extra:
+        if " -m " in extra or "--max-mem" in extra:
             sys.exit(
                 "You have provided `-m/--max-mem` in `params.extra`; please use `resources.mem_mb`."
             )


### PR DESCRIPTION
Currently, it is checked whether or not the memory settings of bcftools are set by the user in the `extra` argument of `params`. This is done by a simple string match whether either `-m` or `--max-mem` is present in the string passed as `extra`.

This is problematic because a simple test for the presents of `-m` would lead to flag valid parameters as attempts to wrongly set the memory requirements. E.g. the wrapper for [freeBayes](https://snakemake-wrappers.readthedocs.io/en/stable/wrappers/freebayes.html) makes use of the functionality of snakemake-wrapper-utils for double-checking the parameters provided to bcftools. However, when parsing the valid `freebayes` argument `--report-monomorphic`, a simple match for `-m` will return `True` and thus stop the pipeline. Adding additional spaces around `-m` could avoid this triggering.