### PR TITLE
fix: set default memory for `get_mem()` to 1/5 of 1GB

### DIFF
--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -5,9 +5,9 @@ def get_mem(snakemake, out_unit="MiB"):
     """
 
     # Store memory in MiB
-    mem_mb = snakemake.resources.get("mem_gb", 0) * 1024
+    mem_mb = snakemake.resources.get("mem_gb", 0.2) * 1024
     if not mem_mb:
-        mem_mb = snakemake.resources.get("mem_mb", 0)
+        mem_mb = snakemake.resources.get("mem_mb", 205)
 
     if out_unit == "KiB":
         return mem_mb * 1024


### PR DESCRIPTION
otherwise we can get cases where the Java virtual machine tries to assign `-Xmx0M` and fails, see: https://github.com/snakemake/snakemake-wrappers/pull/1450#issuecomment-1611111398