### PR TITLE
fix: bug where mem_mb is never read

### DIFF
--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -5,9 +5,7 @@ def get_mem(snakemake, out_unit="MiB"):
     """
 
     # Store memory in MiB
-    mem_mb = snakemake.resources.get("mem_gb", 0.2) * 1024
-    if not mem_mb:
-        mem_mb = snakemake.resources.get("mem_mb", 205)
+    mem_mb = snakemake.resources.get("mem_gb", snakemake.resources.get("mem_mb", 205))
 
     if out_unit == "KiB":
         return mem_mb * 1024

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -1,11 +1,15 @@
 def get_mem(snakemake, out_unit="MiB"):
     """
     Obtain requested memory (from resources) and return in given units.
-    If no memory resources found, return a value equivalent to 205 MiB.
+    If no memory resources found, return a value equivalent to 205 .
     """
 
     # Store memory in MiB
-    mem_mb = snakemake.resources.get("mem_gb", snakemake.resources.get("mem_mb", 205))
+
+    if mem_mb := snakemake.resources.get("mem_gb", None):
+        mem_mb *= 1024
+    else:
+        mem_mb = snakemake.resources.get("mem_mb", 205)
 
     if out_unit == "KiB":
         return mem_mb * 1024

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -1,7 +1,7 @@
 def get_mem(snakemake, out_unit="MiB"):
     """
     Obtain requested memory (from resources) and return in given units.
-    If no memory resources found, return 0.
+    If no memory resources found, return a value equivalent to 205 MiB.
     """
 
     # Store memory in MiB

--- a/tests/test_snakemake_wrapper_utils.py
+++ b/tests/test_snakemake_wrapper_utils.py
@@ -2,4 +2,4 @@ from snakemake_wrapper_utils import __version__
 
 
 def test_version():
-    assert __version__ == '0.1.0'
+    assert __version__ == "0.1.0"


### PR DESCRIPTION
When mem_gb does not exist, it was set to a default of 0.2, which made the next line never trigger. This result was that mem_mb was never read.