### PR TITLE
fix: typo on samtools regions file

### DIFF
--- a/snakemake_wrapper_utils/samtools.py
+++ b/snakemake_wrapper_utils/samtools.py
@@ -31,10 +31,9 @@ def get_samtools_opts(
             sys.exit(
                 "You have specified number of threads (`-@/--threads`) in `params.extra`; this is automatically infered from `threads`."
             )
-        samtools_opts += (
-            ""
-            if snakemake.threads <= 1
-            else " --threads {}".format(snakemake.threads - 1)
+
+        if snakemake.threads > 1:
+            samtools_opts += f" --threads {snakemake.threads - 1}"
         )
 
     ######################

--- a/snakemake_wrapper_utils/samtools.py
+++ b/snakemake_wrapper_utils/samtools.py
@@ -55,11 +55,11 @@ def get_samtools_opts(
     if parse_regions:
         if is_arg("--region-file", extra) or is_arg("--regions-file", extra):
             sys.exit(
-                "You have specified regions file (`--regions-file`) in `params.extra`; this is automatically infered from `regions` input file."
+                "You have specified regions file (`--region[s]-file`) in `params.extra`; this is automatically infered from `regions` input file."
             )
 
         if snakemake.input.get("regions"):
-            samtools_opts += f" --regions-file {snakemake.input.regions}"
+            samtools_opts += f" --region-file {snakemake.input.regions}"
 
     ###################
     ### Write index ###


### PR DESCRIPTION
Fix typo on `samtools` option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated error messaging for region file arguments to support both singular and plural forms.
  - Aligned the command option construction with the revised messaging for improved clarity.
  - Simplified logic for appending thread options to enhance flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->