### PR TITLE
feat: Mem overhead

### DIFF
--- a/snakemake_wrapper_utils/java.py
+++ b/snakemake_wrapper_utils/java.py
@@ -3,11 +3,17 @@ from snakemake_wrapper_utils.snakemake import get_mem, is_arg
 
 
 def java_mem_xmx_error(params_key):
-    return f"You have specified memory under `resources` and provided `-Xmx` in params.{params_key}. For Java memory specifications, please use only `resources.mem_mb` (for total memory reserved for the rule) and `params.java_mem_overhead_mb` (to specify any required non-heap overhead that needs to be set aside before determining the `-Xmx` value)."
+    return f"You have specified memory under `resources` and provided `-Xmx` in params.{params_key}. For Java memory specifications, please use only `resources.mem_mb`."
 
 
 def get_java_opts(snakemake, java_mem_overhead_factor=0.2):
-    """Obtain java_opts from params, and handle resource definitions in resources."""
+    """
+    Obtain java_opts from params, and handle resource definitions in resources.
+
+    java_mem_overhead_factor:
+        a fraction of total reserved memory, which is set aside for non-heap overhead
+        by subtracting it from the value passed to `-Xmx`
+    """
 
     java_opts = snakemake.params.get("java_opts", "")
     extra = snakemake.params.get("extra", "")

--- a/snakemake_wrapper_utils/java.py
+++ b/snakemake_wrapper_utils/java.py
@@ -8,6 +8,7 @@ def java_mem_xmx_error(params_key):
 
 def get_java_opts(snakemake, java_mem_overhead_factor=0.2):
     """Obtain java_opts from params, and handle resource definitions in resources."""
+    import math
 
     java_opts = snakemake.params.get("java_opts", "")
     extra = snakemake.params.get("extra", "")
@@ -19,7 +20,7 @@ def get_java_opts(snakemake, java_mem_overhead_factor=0.2):
     if "-Xmx" in extra:
         sys.exit(java_mem_xmx_error("extra"))
     java_opts += " -Xmx{}M".format(
-        round(get_mem(snakemake) * (1.0 - java_mem_overhead_factor))
+        math.floor(get_mem(snakemake) * (1.0 - java_mem_overhead_factor))
     )
 
     # Getting java temp directory

--- a/snakemake_wrapper_utils/java.py
+++ b/snakemake_wrapper_utils/java.py
@@ -19,7 +19,7 @@ def get_java_opts(snakemake, java_mem_overhead_factor=0.2):
     if "-Xmx" in extra:
         sys.exit(java_mem_xmx_error("extra"))
     java_opts += " -Xmx{}M".format(
-        get_mem(snakemake, out_unit="MiB", java_mem_overhead_factor)
+        get_mem(snakemake, out_unit="MiB", mem_overhead_factor=java_mem_overhead_factor)
     )
 
     # Getting java temp directory

--- a/snakemake_wrapper_utils/java.py
+++ b/snakemake_wrapper_utils/java.py
@@ -8,7 +8,6 @@ def java_mem_xmx_error(params_key):
 
 def get_java_opts(snakemake, java_mem_overhead_factor=0.2):
     """Obtain java_opts from params, and handle resource definitions in resources."""
-    import math
 
     java_opts = snakemake.params.get("java_opts", "")
     extra = snakemake.params.get("extra", "")
@@ -20,7 +19,7 @@ def get_java_opts(snakemake, java_mem_overhead_factor=0.2):
     if "-Xmx" in extra:
         sys.exit(java_mem_xmx_error("extra"))
     java_opts += " -Xmx{}M".format(
-        math.floor(get_mem(snakemake) * (1.0 - java_mem_overhead_factor))
+        get_mem(snakemake, out_unit="MiB", java_mem_overhead_factor)
     )
 
     # Getting java temp directory

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -1,4 +1,4 @@
-def get_mem(snakemake, out_unit="MiB"):
+def get_mem(snakemake, out_unit="MiB", mem_overhead_factor=0):
     """
     Obtain requested memory (from resources) and return in given units.
     If no memory resources found, return a value equivalent to 205.
@@ -12,7 +12,6 @@ def get_mem(snakemake, out_unit="MiB"):
         mem_mb = snakemake.resources.get("mem_mb", 205)
 
     # Apply memory overhead
-    mem_overhead_factor = snakemake.params.get("mem_overhead_factor", 0)
     assert 0 <= mem_overhead_factor < 1, f"mem_overhead_factor must be between 0 and 1, got {mem_overhead_factor}"
     mem_mb *= 1 - mem_overhead_factor
 

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -25,7 +25,7 @@ def get_mem(snakemake, out_unit="MiB", mem_overhead_factor=0):
     elif out_unit == "GiB":
         return mem_mb / 1024
     else:
-        raise valueError("invalid output unit. Only B, KiB, MiB and GiB supported.")
+        raise ValueError("invalid output unit. Only B, KiB, MiB and GiB supported.")
 
 
 def is_arg(arg, cmd):

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -13,9 +13,9 @@ def get_mem(snakemake, out_unit="MiB", mem_overhead_factor=0):
         mem_mb = snakemake.resources.get("mem_mb", 205)
 
     # Apply memory overhead
-    assert 0 <= mem_overhead_factor < 1, f"mem_overhead_factor must be between 0 and 1, got {mem_overhead_factor}"
+    if not (0 <= mem_overhead_factor < 1):
+        raise ValueError(f"mem_overhead_factor must be >= 0 and < 1, got {mem_overhead_factor}")
     mem_mb = math.floor(mem_mb * (1 - mem_overhead_factor))
-
     # Return memory
     if out_unit == "B":
         return mem_mb * 1024 * 1024

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -1,7 +1,7 @@
 def get_mem(snakemake, out_unit="MiB", mem_overhead_factor=0):
     """
     Obtain requested memory (from resources) and return in given units.
-    If no memory resources found, return a value equivalent to 205.
+    If no memory resources found, return a value equivalent to 205 MiB.
     """
 
     # Store memory in MiB
@@ -16,14 +16,16 @@ def get_mem(snakemake, out_unit="MiB", mem_overhead_factor=0):
     mem_mb *= 1 - mem_overhead_factor
 
     # Return memory
-    if out_unit == "KiB":
+    if out_unit == "B":
+        return mem_mb * 1024 * 1024
+    elif out_unit == "KiB":
         return mem_mb * 1024
     elif out_unit == "MiB":
         return mem_mb
     elif out_unit == "GiB":
         return mem_mb / 1024
     else:
-        raise valueError("invalid output unit. Only KiB, MiB and GiB supported.")
+        raise valueError("invalid output unit. Only B, KiB, MiB and GiB supported.")
 
 
 def is_arg(arg, cmd):

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -11,6 +11,12 @@ def get_mem(snakemake, out_unit="MiB"):
     else:
         mem_mb = snakemake.resources.get("mem_mb", 205)
 
+    # Apply memory overhead
+    mem_overhead_factor = snakemake.params.get("mem_overhead_factor", 0)
+    assert 0 <= mem_overhead_factor < 1, f"mem_overhead_factor must be between 0 and 1, got {mem_overhead_factor}"
+    mem_mb *= 1 - mem_overhead_factor
+
+    # Return memory
     if out_unit == "KiB":
         return mem_mb * 1024
     elif out_unit == "MiB":

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -3,6 +3,7 @@ def get_mem(snakemake, out_unit="MiB", mem_overhead_factor=0):
     Obtain requested memory (from resources) and return in given units.
     If no memory resources found, return a value equivalent to 205 MiB.
     """
+    import math
 
     # Store memory in MiB
 
@@ -13,7 +14,7 @@ def get_mem(snakemake, out_unit="MiB", mem_overhead_factor=0):
 
     # Apply memory overhead
     assert 0 <= mem_overhead_factor < 1, f"mem_overhead_factor must be between 0 and 1, got {mem_overhead_factor}"
-    mem_mb *= 1 - mem_overhead_factor
+    mem_mb = math.floor(mem_mb * (1 - mem_overhead_factor))
 
     # Return memory
     if out_unit == "B":


### PR DESCRIPTION
Add option provide a memory scaling factor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Support for specifying a memory overhead factor when retrieving memory values.
  - Enhanced memory reporting adds bytes (B) alongside KiB, MiB, GiB.
  - Java memory option generation now uses the adjusted memory value that accounts for overhead.
  - Maintains a 205 MiB fallback when no memory resource is provided.

- **Bug Fixes**
  - Validation ensures memory overhead factor is within 0 (inclusive) and 1 (exclusive).
  - Improved error message for unsupported output units.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->