### PR TITLE
fix: Add more FASTA extensions

### DIFF
--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -34,8 +34,8 @@ def get_format(path):
         raise ValueError("Path cannot be empty")
     exts = Path(path).suffixes
     if not exts:
-        raise ValueError("Path must have an extension")
-    if exts[-1] in (".gz", ".bgz", ".bz2"):
+        raise ValueError("Path must have an extension.")
+    if exts[-1] in (".gz", ".bgz", ".bz2", ".xz"):
         ext = exts[-2]
     else:
         ext = exts[-1]

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -28,6 +28,7 @@ def is_arg(arg, cmd):
 
 def get_format(path):
     from pathlib import Path
+
     """Get file format from extension, ignoring common compressions."""
     if not path:
         raise ValueError("Path cannot be empty")
@@ -41,7 +42,8 @@ def get_format(path):
 
     if ext in (".fq", ".fastq"):
         return "fastq"
-    elif ext in (".fa", ".fas", ".fna", ".fasta"):
+    elif ext in (".fa", ".fas", ".fna", ".ffn", ".faa", ".fasta", ".mpfa", ".frn"):
+        # https://en.wikipedia.org/wiki/FASTA_format
         return "fasta"
     else:
         return ext.lstrip(".").lower()


### PR DESCRIPTION
Fixes #48 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Broader recognition of FASTA files by adding several common extensions (`.ffn`, `.faa`, `.mpfa`, `.frn`) and support for `.xz` compressed files.

- **Documentation**
  - Added an inline reference to the FASTA format for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->