### PR TITLE
feat: move temp output to final destinations

### DIFF
--- a/snakemake_wrapper_utils/bcftools.py
+++ b/snakemake_wrapper_utils/bcftools.py
@@ -140,7 +140,7 @@ def get_bcftools_opts(
         or is_arg("--temp-prefix", extra)
     ):
         sys.exit(
-            "You have provided `-T/--temp-dir/--temp-prefix` in `params.extra`; please use the `tmpdir` resource."
+            "You have provided `-T/--temp-dir/--temp-prefix` in `params.extra`; please use `resources.tmpdir`."
         )
 
     return bcftools_opts

--- a/snakemake_wrapper_utils/java.py
+++ b/snakemake_wrapper_utils/java.py
@@ -3,7 +3,7 @@ from snakemake_wrapper_utils.snakemake import get_mem, is_arg
 
 
 def java_mem_xmx_error(params_key):
-    return f"You have provided `-Xmx` in params.{params_key}. For Java memory specifications, please only use resources.mem_mb (for total memory reserved for the rule) and `params.java_mem_overhead_mb` (to specify any required non-heap overhead that needs to be set aside before determining the `-Xmx` value)."
+    return f"You have specified memory under `resources` and provided `-Xmx` in params.{params_key}. For Java memory specifications, please use only `resources.mem_mb` (for total memory reserved for the rule) and `params.java_mem_overhead_mb` (to specify any required non-heap overhead that needs to be set aside before determining the `-Xmx` value)."
 
 
 def get_java_opts(snakemake, java_mem_overhead_factor=0.2):

--- a/snakemake_wrapper_utils/samtools.py
+++ b/snakemake_wrapper_utils/samtools.py
@@ -29,7 +29,7 @@ def get_samtools_opts(
     if parse_threads:
         if is_arg("-@", extra) or is_arg("--threads", extra):
             sys.exit(
-                "You have specified number of threads (`-@/--threads`) in `params.extra`; this is automatically infered from `threads`."
+                "You have specified number of threads (`-@/--threads`) in `params.extra`; please use `threads`."
             )
 
         if snakemake.threads > 1:

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -62,15 +62,13 @@ def move_files(snakemake, mapping, cmd="mv -v"):
     Example:
         mapping = {"tsv": "/tmp/tmp98723489/results/out.tsv"}
 
-        # In the wrapper, one shell per move operation, logging needs to append:
-        #
-        # for file in move_files(snakemake, mapping):
-        #     shell("{file} {log}")
-        #
+        # In the wrapper, one shell per move operation:
+        for file in move_files(snakemake, mapping):
+            shell("{file} {log}")
+
         # In the wrapper, one shell command for all move statements:
-        #
-        # move_commands = "; ".join(move_files(snakemake, mapping))
-        # shell("( {move_commands} ) {log}")
+        move_cmds = "; ".join(move_files(snakemake, mapping))
+        shell("( {move_cmds} ) {log}")
     """
 
     cmds = []

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -62,6 +62,7 @@ def move_files(snakemake, mapping, cmd="mv --verbose"):
     """
 
     import contextlib
+    from snakemake.shell import shell
 
     with open(snakemake.log[0], "a", buffering=1) as log:
         with contextlib.redirect_stdout(log):
@@ -69,7 +70,7 @@ def move_files(snakemake, mapping, cmd="mv --verbose"):
                 for out_tag, tool_out_name in mapping.items():
                     out_name = snakemake.output.get(out_tag, "")
                     if out_name:
-                        shell(f"{cmd} {tool_out_name} {out_name}")
+                        shell("{cmd} {tool_out_name:q} {out_name:q}")
                     else:
                         raise KeyError(
                             f"The wrapper requires the named output: {out_tag}. Please provide this named output."

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -61,9 +61,16 @@ def move_files(snakemake, mapping, cmd="mv -v"):
 
     Example:
         mapping = {"tsv": "/tmp/tmp98723489/results/out.tsv"}
-        # In the wrapper:
+
+        # In the wrapper, one shell per move operation, logging needs to append:
+        #
         # for file in move_files(snakemake, mapping):
         #     shell("{file} {log}")
+        #
+        # In the wrapper, one shell command for all move statements:
+        #
+        # move_commands = "; ".join(move_files(snakemake, mapping))
+        # shell("( {move_commands} ) {log}")
     """
 
     cmds = []

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -62,16 +62,17 @@ def move_files(snakemake, mapping, cmd="mv -v"):
     Example:
         mapping = {"tsv": "/tmp/tmp98723489/results/out.tsv"}
         # In the wrapper:
-        # shell(f"( set -euo pipefail; {move_files(snakemake, mapping)} ) {snakemake.log_fmt_shell(stdout=True, stderr=True)}")
+        # for file in move_files(snakemake, mapping):
+        #     shell("{file} {log}")
     """
 
-    cmds = list()
+    cmds = []
     for out_tag, tool_out_name in mapping.items():
         out_name = snakemake.output.get(out_tag, "")
         if not out_name:
             raise KeyError(
                 f"The wrapper requires the named output: {out_tag}. Please provide this named output."
             )
-        cmds.append("{cmd} {tool_out_name:q} {out_name:q}")
+        cmds.append(f"{cmd} '{tool_out_name}' '{out_name}'")
 
     return cmds

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -54,15 +54,15 @@ def get_format(path):
 
 def move_files(snakemake, mapping, cmd="mv -v"):
     """
-    Move file(s) produced by the tool to the named Snakemake outputs.
+    Build shell move commands for relocating tool-produced files to named outputs.
 
-    mapping must be a dict of {out_tag: source_path}.
+    mapping must be a dict of {out_tag: source_path}. The out_tag must resolve
+    to a single file path in snakemake.output.
 
     Example:
         mapping = {"tsv": "/tmp/tmp98723489/results/out.tsv"}
-
-    This moves /tmp/tmp98723489/results/out.tsv to snakemake.output["tsv"],
-    redirecting stdout/stderr to snakemake.log.
+        # In the wrapper:
+        # shell(f"( set -euo pipefail; {move_files(snakemake, mapping)} ) {snakemake.log_fmt_shell(stdout=True, stderr=True)}")
     """
 
     cmds = list()

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -53,7 +53,7 @@ def get_format(path):
         return ext
 
 
-def move_files(snakemake, mapping, cmd="mv --verbose"):
+def move_files(snakemake, mapping, cmd="mv -v"):
     """
     Move file(s) produced by the tool to the named Snakemake outputs.
 

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -44,13 +44,12 @@ def get_format(path):
     else:
         ext = exts[-1]
 
-    ext = ext.lstrip(".")
-    if ext in ("fq", "fastq"):
+    if ext in (".fq", ".fastq"):
         return "fastq"
-    elif ext in ("fa", "fas", "fna", "fasta"):
+    elif ext in (".fa", ".fas", ".fna", ".fasta"):
         return "fasta"
     else:
-        return ext
+        return ext.lstrip(".")
 
 
 def move_files(snakemake, mapping, cmd="mv -v"):
@@ -66,15 +65,13 @@ def move_files(snakemake, mapping, cmd="mv -v"):
     redirecting stdout/stderr to snakemake.log.
     """
 
-    from snakemake.shell import shell
-
-    log = snakemake.log_fmt_shell(stdout=True, stderr=True, append=True)
-
+    cmds = list()
     for out_tag, tool_out_name in mapping.items():
         out_name = snakemake.output.get(out_tag, "")
-        if out_name:
-            shell("{cmd} {tool_out_name:q} {out_name:q} {log}")
-        else:
+        if not out_name:
             raise KeyError(
                 f"The wrapper requires the named output: {out_tag}. Please provide this named output."
             )
+        cmds.append("{cmd} {tool_out_name:q} {out_name:q}")
+
+    return cmds

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -50,11 +50,15 @@ def get_format(path):
 
 def move_files(snakemake, mapping, cmd="mv --verbose"):
     """
-    Given the dict:
-    mapping = {"tsv": "/tmp/tmp98723489/out.tsv,}
+    Move file(s) produced by the tool to the named Snakemake outputs.
 
-    Move file /tmp/tmp98723489/results/out.tsv to snakemake.output.tsv,
-    and redirect stdout and stderr to snakemake.log.
+    mapping must be a dict of {out_tag: source_path}.
+
+    Example:
+        mapping = {"tsv": "/tmp/tmp98723489/results/out.tsv"}
+
+    This moves /tmp/tmp98723489/results/out.tsv to snakemake.output["tsv"],
+    redirecting stdout/stderr to snakemake.log if defined.
     """
 
     import contextlib

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -68,7 +68,7 @@ def move_files(snakemake, mapping, cmd="mv -v"):
 
         # In the wrapper, one shell command for all move statements:
         move_cmds = "; ".join(move_files(snakemake, mapping))
-        shell("( {move_cmds} ) {log}")
+        shell("(main_wrapper_cmd [...]; {move_cmds}) {log}")
     """
 
     cmds = []

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -18,7 +18,7 @@ def get_mem(snakemake, out_unit="MiB"):
     elif out_unit == "GiB":
         return mem_mb / 1024
     else:
-        raise valueError("invalid output unit. Only KiB, MiB and GiB supported.")
+        raise ValueError("invalid output unit. Only KiB, MiB and GiB supported.")
 
 
 def is_arg(arg, cmd):
@@ -32,20 +32,25 @@ def get_format(path):
     """Get file format from extension, ignoring common compressions."""
     if not path:
         raise ValueError("Path cannot be empty")
-    exts = Path(path).suffixes
+    exts = [s.lower() for s in Path(path).suffixes]
     if not exts:
         raise ValueError("Path must have an extension")
-    if exts[-1] in (".gz", ".bgz", ".bz2"):
+    if exts[-1] in (".gz", ".bgz", ".bz2", ".xz"):
+        if len(exts) < 2:
+            raise ValueError(
+                "Compressed path must include a base extension before the compression suffix, e.g., '.vcf.gz'."
+            )
         ext = exts[-2]
     else:
         ext = exts[-1]
 
-    if ext in (".fq", ".fastq"):
+    ext = ext.lstrip(".")
+    if ext in ("fq", "fastq"):
         return "fastq"
-    elif ext in (".fa", ".fas", ".fna", ".fasta"):
+    elif ext in ("fa", "fas", "fna", "fasta"):
         return "fasta"
     else:
-        return ext.lstrip(".").lower()
+        return ext
 
 
 def move_files(snakemake, mapping, cmd="mv --verbose"):

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -28,6 +28,7 @@ def is_arg(arg, cmd):
 
 def get_format(path):
     from pathlib import Path
+
     """Get file format from extension, ignoring common compressions."""
     if not path:
         raise ValueError("Path cannot be empty")
@@ -45,3 +46,20 @@ def get_format(path):
         return "fasta"
     else:
         return ext.lstrip(".").lower()
+
+
+def mv_temp(snakemake, mapping, cmd="mv --verbose"):
+
+    import contextlib
+
+    with open(snakemake.log[0], "a", buffering=1) as log:
+        with contextlib.redirect_stdout(log):
+            with contextlib.redirect_stderr(log):
+                for out_tag, tool_out_name in mapping.items():
+                    out_name = snakemake.output.get(out_tag, "")
+                    if out_name:
+                        shell(f"{cmd} {tool_out_name} {out_name}")
+                    else:
+                        raise KeyError(
+                            f"The wrapper requires the named output: {out_tag}. Please provide this named output."
+                        )

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -58,20 +58,18 @@ def move_files(snakemake, mapping, cmd="mv --verbose"):
         mapping = {"tsv": "/tmp/tmp98723489/results/out.tsv"}
 
     This moves /tmp/tmp98723489/results/out.tsv to snakemake.output["tsv"],
-    redirecting stdout/stderr to snakemake.log if defined.
+    redirecting stdout/stderr to snakemake.log.
     """
 
-    import contextlib
     from snakemake.shell import shell
 
-    with open(snakemake.log[0], "a", buffering=1) as log:
-        with contextlib.redirect_stdout(log):
-            with contextlib.redirect_stderr(log):
-                for out_tag, tool_out_name in mapping.items():
-                    out_name = snakemake.output.get(out_tag, "")
-                    if out_name:
-                        shell("{cmd} {tool_out_name:q} {out_name:q}")
-                    else:
-                        raise KeyError(
-                            f"The wrapper requires the named output: {out_tag}. Please provide this named output."
-                        )
+    log = snakemake.log_fmt_shell(stdout=True, stderr=True, append=True)
+
+    for out_tag, tool_out_name in mapping.items():
+        out_name = snakemake.output.get(out_tag, "")
+        if out_name:
+            shell("{cmd} {tool_out_name:q} {out_name:q} {log}")
+        else:
+            raise KeyError(
+                f"The wrapper requires the named output: {out_tag}. Please provide this named output."
+            )

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -48,7 +48,14 @@ def get_format(path):
         return ext.lstrip(".").lower()
 
 
-def mv_temp(snakemake, mapping, cmd="mv --verbose"):
+def move_files(snakemake, mapping, cmd="mv --verbose"):
+    """
+    Given the dict:
+    mapping = {"tsv": "/tmp/tmp98723489/out.tsv,}
+
+    Move file /tmp/tmp98723489/results/out.tsv to snakemake.output.tsv,
+    and redirect stdout and stderr to snakemake.log.
+    """
 
     import contextlib
 


### PR DESCRIPTION
Fixes #50 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a helper to move temporary outputs to final locations with clear errors when named outputs are missing.
  - Improved file-format detection to better handle compressed files and normalize fastq/fasta extensions.

- Bug Fixes
  - Corrected exception type for invalid memory-unit reporting.
  - Stricter validation for compressed paths lacking a base extension.

- Documentation
  - Clarified temp-dir/prefix guidance to use resources.tmpdir.
  - Updated Java memory guidance to reference resources.mem_mb.
  - Updated thread guidance to instruct using the threads parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->