### PR TITLE
feat: Read and write variant files

### DIFF
--- a/snakemake_wrapper_utils/bcftools.py
+++ b/snakemake_wrapper_utils/bcftools.py
@@ -179,7 +179,7 @@ def read_write_variants(snakemake, variant_key_name="call"):
         )
 
     if isinstance(variant_key_name, int):
-        out_call = snakemake.output[0]
+        out_call = snakemake.output[variant_key_name]
     else:
         out_call = snakemake.output.get(variant_key_name)
     output_file_name = out_call

--- a/snakemake_wrapper_utils/bcftools.py
+++ b/snakemake_wrapper_utils/bcftools.py
@@ -144,3 +144,52 @@ def get_bcftools_opts(
         )
 
     return bcftools_opts
+
+
+def read_write_variants(snakemake, variant_key_name="call"):
+    """Obtain command lines to read gzipped VCF or BCF files and path to named pipes"""
+    in_call = snakemake.input.get(variant_key_name)
+    min_threads: 1
+    if not in_call:
+        raise KeyError(
+            f"Could not find {variant_key_name} within available snakemake input keys"
+        )
+
+    command_lines = ""
+    input_file_name = in_call
+    if str(in_call).endswith((".gz", ".bcf")):
+        input_file_name = "snakemake_wrapper_utils_read_variants.vcf"
+        min_threads += 1
+
+        # Case there is a comparison:
+        bcftools_opts = get_bcftools_opts(
+            snakemake,
+            parse_threads=False,  # Since no additional threads are required for reading
+            parse_output=False,  # Since we do not write to any file
+            parse_output_format=False,
+        )
+
+        # Create named pipe
+        command_lines += str(
+            f"mkfifo {input_file_name} ; "
+            f"bcftools view {bcftools_opts} {in_call} > {input_file_name} & "
+        )
+
+    out_call = snakemake.output.get(variant_key_name)
+    output_file_name = out_call
+    if str(out_call).endswith((".gz", ".bcf")):
+        output_file_name = "snakemake_wrapper_utils_write_variants.vcf"
+        min_threads += 1
+
+        # This time, we include threading and output formats
+        bcftools_opts = get_bcftools_opts(snakemake)
+        command_lines += str(
+            f"mkfifo {output_file_name} ; "
+            f"bcftools view {bcftools_opts} < {output_file_name} & "
+        )
+
+    if snakemake.threads < min_threads:
+        raise ValueError(
+            f"At least {min_threads} threads required, got {snakemake.threads}"
+        )
+    return command_lines, input_file_name, output_file_name

--- a/snakemake_wrapper_utils/bcftools.py
+++ b/snakemake_wrapper_utils/bcftools.py
@@ -148,7 +148,10 @@ def get_bcftools_opts(
 
 def read_write_variants(snakemake, variant_key_name="call"):
     """Obtain command lines to read gzipped VCF or BCF files and path to named pipes"""
-    in_call = snakemake.input.get(variant_key_name)
+    if isinstance(variant_key_name, int):
+        in_call = snakemake.input[0]
+    else:
+        in_call = snakemake.input.get(variant_key_name)
     min_threads = 1
     if not in_call:
         raise KeyError(
@@ -158,7 +161,7 @@ def read_write_variants(snakemake, variant_key_name="call"):
     command_lines = ""
     input_file_name = in_call
     if str(in_call).endswith((".gz", ".bcf")):
-        input_file_name = "snakemake_wrapper_utils_read_variants.vcf"
+        input_file_name = f"{in_call}.snakemake_wrapper_utils_read_variants.vcf"
         min_threads += 1
 
         # Case there is a comparison:
@@ -175,23 +178,25 @@ def read_write_variants(snakemake, variant_key_name="call"):
             f"bcftools view {bcftools_opts} {in_call} > {input_file_name} & "
         )
 
-    out_call = snakemake.output.get(variant_key_name)
+    if isinstance(variant_key_name, int):
+        out_call = snakemake.output[0]
+    else:
+        out_call = snakemake.output.get(variant_key_name)
     output_file_name = out_call
     if not out_call:
         raise KeyError(
             f"Could not find {variant_key_name} within available snakemake output keys"
         )
 
-
     if str(out_call).endswith((".gz", ".bcf")):
-        output_file_name = "snakemake_wrapper_utils_write_variants.vcf"
+        output_file_name = f"{out_call}.snakemake_wrapper_utils_write_variants.vcf"
         min_threads += 1
 
         # This time, we include threading and output formats
         bcftools_opts = get_bcftools_opts(snakemake)
         command_lines += str(
             f"mkfifo {output_file_name} ; "
-            f"bcftools view {bcftools_opts} < {output_file_name} & "
+            f"bcftools view {bcftools_opts} {output_file_name} & "
         )
 
     if snakemake.threads < min_threads:

--- a/snakemake_wrapper_utils/bcftools.py
+++ b/snakemake_wrapper_utils/bcftools.py
@@ -149,7 +149,7 @@ def get_bcftools_opts(
 def read_write_variants(snakemake, variant_key_name="call"):
     """Obtain command lines to read gzipped VCF or BCF files and path to named pipes"""
     in_call = snakemake.input.get(variant_key_name)
-    min_threads: 1
+    min_threads = 1
     if not in_call:
         raise KeyError(
             f"Could not find {variant_key_name} within available snakemake input keys"
@@ -177,6 +177,12 @@ def read_write_variants(snakemake, variant_key_name="call"):
 
     out_call = snakemake.output.get(variant_key_name)
     output_file_name = out_call
+    if not out_call:
+        raise KeyError(
+            f"Could not find {variant_key_name} within available snakemake output keys"
+        )
+
+
     if str(out_call).endswith((".gz", ".bcf")):
         output_file_name = "snakemake_wrapper_utils_write_variants.vcf"
         min_threads += 1

--- a/snakemake_wrapper_utils/gatk.py
+++ b/snakemake_wrapper_utils/gatk.py
@@ -25,16 +25,16 @@ def get_gatk_opts(
     if parse_arg_file:
         if is_arg("--arguments_file", extra):
             sys.exit(
-                "You have specified an argument file (`--argument_file`) in `params.extra`; this is automatically inferred from `input.arg_file`."
+                "You have specified an argument file (`--arguments_file`) in `params.extra`; this is automatically inferred from `input.arg_file`."
             )
 
         # Multiple argument files can be provided. Order matters.
         arg_file = snakemake.input.get("arg_file", "")
         if arg_file:
             if isinstance(arg_file, list):
-                arg_file = " --argument_file ".join(arg_file)
+                arg_file = " --arguments_file ".join(arg_file)
 
-            gatk_opts += f" --argument_file {arg_file}"
+            gatk_opts += f" --arguments_file {arg_file}"
 
     ######################
     ### Reference file ###


### PR DESCRIPTION
This is a draft for #55 

Tools like `picard` don't handle writing to `stderr`, so I chose to use `mkfifo` instead of pipes.

Does this mean `bcftools` would have to be included in `snakemake-wrappers-utils` ?

Usage within wrappers would look like:

```py
from snakemake_wrapper_utils.bcftools import get_bcftools_opts, read_write_variants

log = snakemake.log_fmt_shell(stdout=False, stderr=True)
extra = snakemake.params.get("extra", "")
read_write_commands, input_file, output_file = read_write_variants(snakemake)

shell(
    "{read_write_commands} "
    "picard RenameSampleInVcf {snakemake.params.extra} "
    "INPUT={input_file} OUTPUT={output_file} {log}"
)
```

Usage within Snakemake would be something like:

```py
rule test_picard_renamesampleinvcf:
    input:
        call="a.bcf",
    output:
       call="renamed.bcf",
    threads: 3
    log: 
        "test_picard_renamesampleinvcf.log",
    params:
       extra="",
    wrapper:
        "master/bio/picard/renamesampleinvcf"
```

Do you think it's worth testing?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added streaming support for variant data via named pipes, handling compressed (gz) and BCF formats and returning the appropriate paths/commands; includes automatic thread and resource validation for safe parallel use.

* **Bug Fixes**
  * Corrected GATK argument-file option naming so generated commands use the correct plural form for argument files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->