### PR TITLE
feat: allow for missing files in mapping

### DIFF
--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -132,10 +132,12 @@ def move_files(snakemake, mapping, cmd="mv -v", required=True):
     cmds = []
     for out_tag, tool_out_name in mapping.items():
         out_name = snakemake.output.get(out_tag, "")
-        if required and not out_name:
-            raise KeyError(
-                f"The wrapper requires the named output: {out_tag}. Please provide this named output."
-            )
-        cmds.append(f"{cmd} '{tool_out_name}' '{out_name}'")
+        if out_name:
+            cmds.append(f"{cmd} '{tool_out_name}' '{out_name}'")
+        else:
+            if required:
+                raise KeyError(
+                    f"The wrapper requires the named output: {out_tag}. Please provide this named output."
+                )
 
     return cmds

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -110,12 +110,12 @@ def get_format(path, ignore_compression=True):
     return ext.lstrip(".")
 
 
-def move_files(snakemake, mapping, cmd="mv -v", strict=True):
+def move_files(snakemake, mapping, cmd="mv -v", required=True):
     """
     Build shell move commands for relocating tool-produced files to named outputs.
 
     mapping must be a dict of {out_tag: source_path}. The out_tag must resolve
-    to a single file path in `snakemake.output` (unless `strict=False`).
+    to a single file path in `snakemake.output` (unless `required=False`).
 
     Example:
         mapping = {"tsv": "/tmp/tmp98723489/results/out.tsv"}
@@ -132,7 +132,7 @@ def move_files(snakemake, mapping, cmd="mv -v", strict=True):
     cmds = []
     for out_tag, tool_out_name in mapping.items():
         out_name = snakemake.output.get(out_tag, "")
-        if strict and not out_name:
+        if required and not out_name:
             raise KeyError(
                 f"The wrapper requires the named output: {out_tag}. Please provide this named output."
             )

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -134,10 +134,9 @@ def move_files(snakemake, mapping, cmd="mv -v", required=True):
         out_name = snakemake.output.get(out_tag, "")
         if out_name:
             cmds.append(f"{cmd} '{tool_out_name}' '{out_name}'")
-        else:
-            if required:
-                raise KeyError(
-                    f"The wrapper requires the named output: {out_tag}. Please provide this named output."
-                )
+        elif required:
+            raise KeyError(
+                f"The wrapper requires the named output: {out_tag}. Please provide this named output."
+            )
 
     return cmds

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -110,7 +110,7 @@ def get_format(path, ignore_compression=True):
     return ext.lstrip(".")
 
 
-def move_files(snakemake, mapping, cmd="mv -v"):
+def move_files(snakemake, mapping, cmd="mv -v", strict=True):
     """
     Build shell move commands for relocating tool-produced files to named outputs.
 
@@ -132,7 +132,7 @@ def move_files(snakemake, mapping, cmd="mv -v"):
     cmds = []
     for out_tag, tool_out_name in mapping.items():
         out_name = snakemake.output.get(out_tag, "")
-        if not out_name:
+        if strict and not out_name:
             raise KeyError(
                 f"The wrapper requires the named output: {out_tag}. Please provide this named output."
             )

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -115,7 +115,7 @@ def move_files(snakemake, mapping, cmd="mv -v", strict=True):
     Build shell move commands for relocating tool-produced files to named outputs.
 
     mapping must be a dict of {out_tag: source_path}. The out_tag must resolve
-    to a single file path in snakemake.output.
+    to a single file path in `snakemake.output` (unless `strict=False`).
 
     Example:
         mapping = {"tsv": "/tmp/tmp98723489/results/out.tsv"}


### PR DESCRIPTION
Right now we assume that all files in the `mapping` are required. By setting `strict=False`, files in mapping that are not specified in `snakemake.output` are ignored.

This specified that all files are either required or optional. Not sure if we could make it file-specific.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `required` option to control whether missing named outputs are treated as errors when moving files.
  * Default behavior remains strict: missing named outputs are still validated and will raise errors unless optional mode is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->