### PR TITLE
feat: test multiple args

### DIFF
--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -42,7 +42,7 @@ def get_arg(arg, cmd):
     except ValueError:
         return None
 
-def get_args(args, cmd)
+def get_args(args, cmd):
     """Return position of multiple arguments on command."""
     return [get_arg(arg, cmd) for arg in args]
 

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -47,7 +47,7 @@ def get_arg(args, cmd):
     if isinstance(args, list):
         return [_get_arg(arg, cmd) for arg in args]
     else:
-        _get_arg(args, cmd)
+        return _get_arg(args, cmd)
 
 
 def is_arg(args, cmd):

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -38,7 +38,7 @@ def list_arg(cmd):
 
 def get_arg(args, cmd):
     """Return position of argument on command."""
-    _get_arg(arg, cmd):
+    def _get_arg(arg, cmd):
         try:
             return list_arg(cmd).index(arg)
         except ValueError:

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -36,17 +36,26 @@ def list_arg(cmd):
     return list(filter(None, cmd.replace("=", " ").split(" ")))
 
 
-def get_arg(arg, cmd):
+def get_arg(args, cmd):
     """Return position of argument on command."""
-    try:
-        return list_arg(cmd).index(arg)
-    except ValueError:
-        return None
+    _get_arg(arg, cmd):
+        try:
+            return list_arg(cmd).index(arg)
+        except ValueError:
+            return None
+
+    if isinstance(args, list):
+        return [_get_arg(arg, cmd) for arg in args]
+    else:
+        _get_arg(args, cmd)
 
 
-def is_arg(arg, cmd):
+def is_arg(args, cmd):
     """Check presence of argument on command."""
-    return get_arg(arg, cmd) is not None
+    if isinstance(args, list):
+        return any([get_arg(arg, cmd) is not None for arg in args])
+    else:
+        return get_arg(args, cmd) is not None
 
 
 def get_format(path, ignore_compression=True):

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -35,28 +35,24 @@ def list_arg(cmd):
     """Turn command into list."""
     return list(filter(None, cmd.replace("=", " ").split(" ")))
 
+def get_arg(arg, cmd):
+"""Return position of argument on command."""
+    try:
+        return list_arg(cmd).index(arg)
+    except ValueError:
+        return None
 
-def get_arg(args, cmd):
-    """Return position of argument on command."""
-    def _get_arg(arg, cmd):
-        try:
-            return list_arg(cmd).index(arg)
-        except ValueError:
-            return None
+def get_args(args, cmd)
+"""Return position of multiple arguments on command."""
+    return [get_arg(arg, cmd) for arg in args]
 
-    if isinstance(args, list):
-        return [_get_arg(arg, cmd) for arg in args]
-    else:
-        return _get_arg(args, cmd)
+def is_arg(arg, cmd):
+"""Check presence of argument on command."""
+    return get_arg(args, cmd) is not None
 
-
-def is_arg(args, cmd):
-    """Check presence of argument on command."""
-    if isinstance(args, list):
-        return any([get_arg(arg, cmd) is not None for arg in args])
-    else:
-        return get_arg(args, cmd) is not None
-
+def are_args(args, cmd):
+"""Check presence of multiple arguments on command."""
+    return [arg is not None for arg in get_args(args, cmd)]
 
 def get_format(path, ignore_compression=True):
     """Get file format from extension, ignoring common compressions on user request"""

--- a/snakemake_wrapper_utils/snakemake.py
+++ b/snakemake_wrapper_utils/snakemake.py
@@ -36,22 +36,22 @@ def list_arg(cmd):
     return list(filter(None, cmd.replace("=", " ").split(" ")))
 
 def get_arg(arg, cmd):
-"""Return position of argument on command."""
+    """Return position of argument on command."""
     try:
         return list_arg(cmd).index(arg)
     except ValueError:
         return None
 
 def get_args(args, cmd)
-"""Return position of multiple arguments on command."""
+    """Return position of multiple arguments on command."""
     return [get_arg(arg, cmd) for arg in args]
 
 def is_arg(arg, cmd):
-"""Check presence of argument on command."""
-    return get_arg(args, cmd) is not None
+    """Check presence of argument on command."""
+    return get_arg(arg, cmd) is not None
 
 def are_args(args, cmd):
-"""Check presence of multiple arguments on command."""
+    """Check presence of multiple arguments on command."""
     return [arg is not None for arg in get_args(args, cmd)]
 
 def get_format(path, ignore_compression=True):


### PR DESCRIPTION
Allow for multiple args when searching a command line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Command-line argument lookup and presence checks now support multiple alternative arguments provided as a list, returning positions and presence results for each entry.

- **Bug Fixes**
  - None. Existing single-argument checks keep the same behavior as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->